### PR TITLE
Fix: SQLITE ERROR On Group Create

### DIFF
--- a/src/entity/Chat.ts
+++ b/src/entity/Chat.ts
@@ -9,7 +9,7 @@ import {
 import { Auth } from "./Auth";
 
 @Entity()
-@Unique(["DBId", "id"])
+@Unique(["DBAuth", "id"])
 export class Chat {
   @PrimaryGeneratedColumn()
   DBId: number;


### PR DESCRIPTION
This change avoid the error 
```
QueryFailedError: SQLITE_ERROR: ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint
```

On create group.